### PR TITLE
Warn when app is not using the latest available version in their Ruby…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     ansi (1.5.0)
-    ci-queue (0.13.6)
+    ci-queue (0.16.0)
       ansi
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
@@ -53,14 +53,14 @@ GEM
     repl_runner (0.0.3)
       activesupport
     rrrretry (1.0.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-retry (0.5.4)
-      rspec-core (> 3.3, < 3.7)
-    rspec-support (3.6.0)
+      rspec-support (~> 3.8.0)
+    rspec-retry (0.6.1)
+      rspec-core (> 3.3)
+    rspec-support (3.8.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     threaded (0.0.4)
@@ -84,5 +84,8 @@ DEPENDENCIES
   rspec-expectations
   rspec-retry
 
+RUBY VERSION
+   ruby 2.5.5p157
+
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -14,6 +14,13 @@ module LanguagePack
       @host_url += File.basename(stack) if stack
     end
 
+    def exists?(path, max_attempts = 1)
+      curl = curl_command("-I #{@host_url.join(path)}")
+      run!(curl, error_class: FetchError, max_attempts: max_attempts, silent: true)
+    rescue FetchError
+      false
+    end
+
     def fetch(path)
       curl = curl_command("-O #{@host_url.join(path)}")
       run!(curl, error_class: FetchError)

--- a/lib/language_pack/installers/ruby_installer.rb
+++ b/lib/language_pack/installers/ruby_installer.rb
@@ -1,6 +1,9 @@
 require "language_pack/shell_helpers"
 module LanguagePack::Installers; end
 
+# This is a base module that is later included by other
+# classes such as LanguagePack::Installers::HerokuRubyInstaller
+#
 module LanguagePack::Installers::RubyInstaller
   include LanguagePack::ShellHelpers
 
@@ -15,6 +18,7 @@ module LanguagePack::Installers::RubyInstaller
   end
 
   def install(ruby_version, install_dir)
+    warn_outdated_version(ruby_version)
     fetch_unpack(ruby_version, install_dir)
     setup_binstubs(install_dir)
   end
@@ -28,5 +32,32 @@ module LanguagePack::Installers::RubyInstaller
       next if vendor_bin.include?("bundle")
       run("ln -s ../#{vendor_bin} #{DEFAULT_BIN_DIR}")
     end
+  end
+
+  # Emits a warning if there are more recent
+  # versions of a ruby version. For example
+  # if an app is using 2.6.1 and 2.6.2 is the latest
+  # it will report that 2.6.2 is available
+  def warn_outdated_version(ruby_version)
+    increment = 1
+    while @fetcher.exists?("#{ruby_version.next_logical_version(increment)}.tgz")
+      increment += 1
+    end
+
+    return false unless increment > 1
+
+    max_version = ruby_version.next_logical_version(increment - 1)
+
+        warn(<<-WARNING)
+There is a more recent Ruby version available for you to use:
+
+#{max_version}
+
+The latest version will include security and bug fixes, we always recommend
+running the latest version of your minor release.
+
+See https://devcenter.heroku.com/articles/ruby-versions for all available versions.
+WARNING
+    return max_version
   end
 end

--- a/lib/language_pack/ruby_version.rb
+++ b/lib/language_pack/ruby_version.rb
@@ -96,6 +96,18 @@ module LanguagePack
       false
     end
 
+    # Returns the next logical version in the minor series
+    # for example if the current ruby version is
+    # `ruby-2.3.1` then then `next_logical_version(1)`
+    # will produce `ruby-2.3.2`.
+    def next_logical_version(increment = 1)
+      return false if patchlevel_is_significant?
+      split_version = @version_without_patchlevel.split(".")
+      teeny = split_version.pop
+      split_version << teeny.to_i + increment
+      split_version.join(".")
+    end
+
     private
 
     def none

--- a/lib/language_pack/shell_helpers.rb
+++ b/lib/language_pack/shell_helpers.rb
@@ -85,7 +85,8 @@ module LanguagePack
     # @option options [Integer] :max_attempts Number of times to attempt command before raising
     def run!(command, options = {})
       max_attempts = options[:max_attempts] || 1
-      error_class = options[:error_class] || StandardError
+      error_class  = options[:error_class] || StandardError
+      silent       = options.key?(:silent) ? options[:silent] : false
       max_attempts.times do |attempt_number|
         result = run(command, options)
         if $?.success?
@@ -94,6 +95,7 @@ module LanguagePack
         if attempt_number == max_attempts - 1
           raise error_class, "Command: '#{command}' failed unexpectedly:\n#{result}"
         else
+          next if silent
           puts "Command: '#{command}' failed on attempt #{attempt_number + 1} of #{max_attempts}."
         end
       end

--- a/spec/helpers/ruby_version_spec.rb
+++ b/spec/helpers/ruby_version_spec.rb
@@ -16,6 +16,20 @@ describe "RubyVersion" do
     @bundler.clean
   end
 
+  it "knows the next logical version" do
+    Hatchet::App.new("ruby_25").in_directory do |dir|
+      ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)
+      version_number = "2.5.0"
+      version        = "ruby-#{version_number}"
+
+      expect(ruby_version.version_without_patchlevel).to eq(version)
+      expect(ruby_version.next_logical_version).to eq("ruby-2.5.1")
+      expect(ruby_version.next_logical_version).to eq("ruby-2.5.1")
+      expect(ruby_version.next_logical_version(2)).to eq("ruby-2.5.2")
+      expect(ruby_version.next_logical_version(20)).to eq("ruby-2.5.20")
+    end
+  end
+
   it "correctly handles patch levels" do
     Hatchet::App.new("mri_193_p547").in_directory do |dir|
       ruby_version   = LanguagePack::RubyVersion.new(@bundler.install.ruby_version, is_new: true)

--- a/spec/installers/heroku_ruby_installer_spec.rb
+++ b/spec/installers/heroku_ruby_installer_spec.rb
@@ -4,8 +4,23 @@ describe LanguagePack::Installers::HerokuRubyInstaller do
   let(:installer)    { LanguagePack::Installers::HerokuRubyInstaller.new("cedar-14") }
   let(:ruby_version) { LanguagePack::RubyVersion.new("ruby-2.3.3") }
 
-  describe "#fetch_unpack" do
+  describe "#version warning" do
+    it "should warn of more recent Ruby versions" do
+      installer = LanguagePack::Installers::HerokuRubyInstaller.new("heroku-16")
+      max_version = installer.warn_outdated_version(ruby_version)
+      expect(max_version).to eq("ruby-2.3.8")
+    end
 
+    it "should not warn when using the most recent ruby version" do
+      installer = LanguagePack::Installers::HerokuRubyInstaller.new("heroku-16")
+      ruby_version = LanguagePack::RubyVersion.new("ruby-2.3.8")
+
+      max_version = installer.warn_outdated_version(ruby_version)
+      expect(max_version).to eq(false)
+    end
+  end
+
+  describe "#fetch_unpack" do
     it "should fetch and unpack mri" do
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do


### PR DESCRIPTION
… series

Developers should be using the latest Ruby version for their minor series. For example currently developers using 2.4.x should be using 2.4.5, if not then this PR will give them a warning:


```
There is a more recent Ruby version available for you to use:

ruby-2.4.5

The latest version will include security and bug fixes, we always recommend
running the latest version of your minor release.

See https://devcenter.heroku.com/articles/ruby-versions for all available versions.
```

This PR does not warn against EOL Ruby versions.

Upside: People don't know there are more recent Ruby versions available

Downside: This adds an extra second to a deploy that a user is not on the latest version (plus 1). For example if a user is using 2.5.0 and the latest is 2.5.5 then it effectively adds 6 seconds to their deploy. 

On one hand this is motivation to use the latest version and you get a free 5 seconds back! Alternatively I can spin up a thread and do this check in the background since the outcome does not affect.

For detecting EOL rubies we can either do a similar version traversal, but with some logic to account for major version bumps as well.